### PR TITLE
makes `buildGraph()` ~10x faster

### DIFF
--- a/src/lib/buildGraph.js
+++ b/src/lib/buildGraph.js
@@ -87,9 +87,11 @@ export default function buildGraph(entryWord, pattern, MAX_DEPTH, progress) {
       return;
     }
 
-    let nextWord = queue.shift();
-    fetchNext(nextWord);
-    progress.updateLayout(queue.length, nextWord);
+    while (queue.length > 0) {
+      let nextWord = queue.shift();
+      fetchNext(nextWord);
+      progress.updateLayout(queue.length, nextWord);
+    }
   }
 
   function fetchNext(query) {


### PR DESCRIPTION
speeds up `loadNext()` by fetching child nodes in parallel